### PR TITLE
Improve editor usability with cursor and copy feature

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -18,7 +18,8 @@ import Animated, {
   runOnJS,
 } from 'react-native-reanimated';
 import { GestureDetector, Gesture } from 'react-native-gesture-handler';
-import { Play, Save, Undo, Redo, Plus, ChevronDown } from 'lucide-react-native';
+import { Play, Save, Undo, Redo, Plus, ChevronDown, ClipboardCopy } from 'lucide-react-native';
+import * as Clipboard from 'expo-clipboard';
 import { CodeKeyboard } from '@/components/CodeKeyboard';
 import { SyntaxHighlighter } from '@/components/SyntaxHighlighter';
 import { TerminalPanel } from '@/components/TerminalPanel';
@@ -111,6 +112,12 @@ for i in range(10):
     }, 100);
   };
 
+  const copyAllText = async () => {
+    try {
+      await Clipboard.setStringAsync(code);
+    } catch {}
+  };
+
   return (
     <SafeAreaView style={styles.container}>
       <TouchableWithoutFeedback onPress={dismissKeyboard}>
@@ -133,6 +140,9 @@ for i in range(10):
                 </TouchableOpacity>
                 <TouchableOpacity style={styles.actionButton}>
                   <Undo size={16} color="#007AFF" />
+                </TouchableOpacity>
+                <TouchableOpacity style={styles.actionButton} onPress={copyAllText}>
+                  <ClipboardCopy size={16} color="#007AFF" />
                 </TouchableOpacity>
               </View>
             </View>
@@ -158,6 +168,7 @@ for i in range(10):
                   multiline
                   textAlignVertical="top"
                   selectionColor="#007AFF"
+                  cursorColor="#007AFF"
                   placeholderTextColor="#8E8E93"
                   autoCapitalize="none"
                   autoCorrect={false}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "expo": "53.0.11",
         "expo-blur": "~14.1.5",
         "expo-camera": "~16.1.8",
+        "expo-clipboard": "^7.1.4",
         "expo-constants": "~17.1.6",
         "expo-font": "~13.3.1",
         "expo-haptics": "~14.1.4",
@@ -4547,6 +4548,17 @@
         "react-native-web": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-clipboard": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/expo-clipboard/-/expo-clipboard-7.1.4.tgz",
+      "integrity": "sha512-NHhfKnrzb4o0PacUKD93ByadU0JmPBoFTFYbbFJZ9OAX6SImpSqG5gfrMUR3vVj4Qx9f1LpMcdAv5lBzv868ow==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-constants": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "expo-symbols": "~0.4.5",
     "expo-system-ui": "~5.0.8",
     "expo-web-browser": "~14.1.6",
+    "expo-clipboard": "^7.1.4",
     "lucide-react-native": "^0.475.0",
     "react": "19.0.0",
     "react-dom": "19.0.0",


### PR DESCRIPTION
## Summary
- show the text cursor by setting `cursorColor`
- allow copying all code using a new `ClipboardCopy` button
- install `expo-clipboard` for clipboard support

## Testing
- `npm run lint` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_6861f9b317cc83278a5680d3c0b3044a