### PR TITLE
Remove search button and add LeetCode link

### DIFF
--- a/app/(tabs)/editor.tsx
+++ b/app/(tabs)/editor.tsx
@@ -10,6 +10,7 @@ import {
   SafeAreaView,
   Keyboard,
   TouchableWithoutFeedback,
+  Linking,
 } from 'react-native';
 import Animated, {
   useSharedValue,
@@ -28,6 +29,7 @@ import {
   Plus,
   ChevronDown,
   Copy,
+  ExternalLink,
 } from 'lucide-react-native';
 //import * as Clipboard from 'expo-clipboard';
 import { CodeKeyboard } from '@/components/CodeKeyboard';
@@ -376,6 +378,14 @@ export default function EditorScreen() {
                 <TouchableOpacity style={styles.actionButton} onPress={runCode}>
                   <Play size={16} color="#007AFF" />
                 </TouchableOpacity>
+                {slug && (
+                  <TouchableOpacity
+                    style={styles.actionButton}
+                    onPress={() => Linking.openURL(`https://leetcode.com/${slug}`)}
+                  >
+                    <ExternalLink size={16} color="#007AFF" />
+                  </TouchableOpacity>
+                )}
                 <TouchableOpacity style={styles.actionButton} onPress={saveFile}>
                   <Save size={16} color="#007AFF" />
                 </TouchableOpacity>

--- a/app/(tabs)/files.tsx
+++ b/app/(tabs)/files.tsx
@@ -8,7 +8,7 @@ import {
   SafeAreaView,
   Alert,
 } from 'react-native';
-import { File, Folder, Plus, Search, MoveVertical as MoreVertical, CreditCard as Edit3, Trash2 } from 'lucide-react-native';
+import { File, Folder, Plus, MoveVertical as MoreVertical, CreditCard as Edit3, Trash2 } from 'lucide-react-native';
 import * as FileSystem from 'expo-file-system';
 import { useRouter } from 'expo-router';
 
@@ -179,9 +179,6 @@ export default function FilesScreen() {
       <View style={styles.header}>
         <Text style={styles.title}>Files</Text>
         <View style={styles.headerActions}>
-          <TouchableOpacity style={styles.headerButton}>
-            <Search size={20} color="#007AFF" />
-          </TouchableOpacity>
           <TouchableOpacity style={styles.headerButton} onPress={handleCreateFile}>
             <Plus size={20} color="#007AFF" />
           </TouchableOpacity>


### PR DESCRIPTION
## Summary
- drop the Search icon from the Files tab
- add a header link to LeetCode in the editor when a problem slug is passed

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868068adf388327b432b4ec981d9ecf