### PR TITLE
Display two-row layout for code keyboard

### DIFF
--- a/components/CodeKeyboard.tsx
+++ b/components/CodeKeyboard.tsx
@@ -101,6 +101,9 @@ export function CodeKeyboard({
   ];
 
   const currentData = tabs.find(tab => tab.key === activeTab)?.data || [];
+  const halfIndex = Math.ceil(currentData.length / 2);
+  const firstRow = currentData.slice(0, halfIndex);
+  const secondRow = currentData.slice(halfIndex);
 
   return (
     <View style={styles.container}>
@@ -132,7 +135,23 @@ export function CodeKeyboard({
         style={styles.keyboardRow}
         contentContainerStyle={styles.keyboardContent}
       >
-        {currentData.map((item, index) => (
+        {firstRow.map((item, index) => (
+          <TouchableOpacity
+            key={index}
+            style={styles.keyButton}
+            onPress={() => onInsert(item.text)}
+          >
+            <Text style={styles.keyText}>{item.label}</Text>
+          </TouchableOpacity>
+        ))}
+      </ScrollView>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        style={styles.keyboardRow}
+        contentContainerStyle={styles.keyboardContent}
+      >
+        {secondRow.map((item, index) => (
           <TouchableOpacity
             key={index}
             style={styles.keyButton}

--- a/components/CodeKeyboard.tsx
+++ b/components/CodeKeyboard.tsx
@@ -82,6 +82,8 @@ const collections = [
   { label: 'Counter', text: 'collections.Counter(' },
   { label: 'OrderedDict', text: 'collections.OrderedDict(' },
   { label: 'deque', text: 'collections.deque(' },
+  { label: 'heappush', text: 'heapq.heappush(' },
+  { label: 'heappop', text: 'heapq.heappop(' },
   { label: 'namedtuple', text: 'collections.namedtuple(' },
 ];
 

--- a/components/CodeKeyboard.tsx
+++ b/components/CodeKeyboard.tsx
@@ -132,7 +132,7 @@ export function CodeKeyboard({
       <ScrollView
         horizontal
         showsHorizontalScrollIndicator={false}
-        style={styles.keyboardRow}
+        style={[styles.keyboardRow, styles.firstRow]}
         contentContainerStyle={styles.keyboardContent}
       >
         {firstRow.map((item, index) => (
@@ -148,7 +148,7 @@ export function CodeKeyboard({
       <ScrollView
         horizontal
         showsHorizontalScrollIndicator={false}
-        style={styles.keyboardRow}
+        style={[styles.keyboardRow, styles.secondRow]}
         contentContainerStyle={styles.keyboardContent}
       >
         {secondRow.map((item, index) => (
@@ -219,6 +219,12 @@ const styles = StyleSheet.create({
   },
   keyboardRow: {
     paddingVertical: 12,
+  },
+  firstRow: {
+    paddingBottom: 6,
+  },
+  secondRow: {
+    paddingTop: 6,
   },
   keyboardContent: {
     paddingHorizontal: 16,


### PR DESCRIPTION
## Summary
- split keyboard snippets into two rows and render each row separately

## Testing
- `npm run lint` *(fails: expo not found)*
- `npm test` *(fails: missing script)*
- `npx tsc --noEmit` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68682641b694832794d6bbd572d66dbe